### PR TITLE
fix: use absolute $HOME paths in home::symlink

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,8 +39,8 @@ TODO: Add a short summary of this module.
 - `p6df::modules::perl::home::symlink()`
 - `p6df::modules::perl::init(_module, dir)`
   - Args:
-    - _module - 
-    - dir - 
+    - _module -
+    - dir -
 - `p6df::modules::perl::langs()`
 - `p6df::modules::perl::vscodes()`
 - `p6df::modules::perl::vscodes::config()`

--- a/init.zsh
+++ b/init.zsh
@@ -63,7 +63,7 @@ p6df::modules::perl::home::symlink() {
   p6_dir_mk "$P6_DFZ_SRC_DIR/tokuhirom/plenv/plugins"
   p6_file_symlink "$P6_DFZ_SRC_DIR/tokuhirom/Perl-Build" "$P6_DFZ_SRC_DIR/tokuhirom/plenv/plugins/perl-build"
 
-  p6_file_symlink "$P6_DFZ_SRC_P6M7G8_DOTFILES_DIR/p6df-perl/share/.cpanm" ".cpanm"
+  p6_file_symlink "$P6_DFZ_SRC_P6M7G8_DOTFILES_DIR/p6df-perl/share/.cpanm" "$HOME/.cpanm"
 
   p6_return_void
 }


### PR DESCRIPTION
Symlink targets were using relative paths (e.g. `.aws`) instead of absolute `$HOME/.aws`. Fixes symlinks when not run from $HOME.