### PR TITLE
fix: suppress default PERL5LIB from prompt env

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,6 +2,10 @@ name: Build
 
 on:
   pull_request: {}
+  push:
+    branches:
+      - gh-readonly-queue/**
+  merge_group: {}
   workflow_dispatch: {}
 
 jobs:

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -2,6 +2,10 @@ name: Claude Code Review
 on:
   pull_request:
     types: [opened, ready_for_review, synchronize]
+  push:
+    branches:
+      - gh-readonly-queue/**
+  merge_group: {}
 
 permissions:
   contents: read
@@ -11,8 +15,13 @@ permissions:
 jobs:
   claude-review:
     runs-on: ubuntu-latest
-    if: github.event.pull_request.draft == false
     steps:
-      - uses: p6m7g8-actions/claude@main
+      - name: Skip on queue refs
+        if: github.event_name == 'merge_group' || github.event_name == 'push'
+        run: echo "Skipping review in queue context"
+      - name: Run claude review
+        if: github.event_name == 'pull_request' && github.event.pull_request.draft == false
+        continue-on-error: true
+        uses: p6m7g8-actions/claude@main
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/.github/workflows/codex-review.yml
+++ b/.github/workflows/codex-review.yml
@@ -2,18 +2,26 @@ name: Codex Code Review
 on:
   pull_request:
     types: [opened, ready_for_review, synchronize]
+  push:
+    branches:
+      - gh-readonly-queue/**
+  merge_group: {}
 
 permissions:
   contents: read
   id-token: write
-  issues: write
   pull-requests: write
 
 jobs:
   codex-review:
     runs-on: ubuntu-latest
-    if: github.event.pull_request.draft == false
     steps:
-      - uses: p6m7g8-actions/codex@main
+      - name: Skip on queue refs
+        if: github.event_name == 'merge_group' || github.event_name == 'push'
+        run: echo "Skipping review in queue context"
+      - name: Run codex review
+        if: github.event_name == 'pull_request' && github.event.pull_request.draft == false && github.event.pull_request.head.repo.fork == false
+        continue-on-error: true
+        uses: p6m7g8-actions/codex@main
         with:
           openai_api_key: ${{ secrets.OPENAI_API_KEY }}

--- a/.github/workflows/pull-request-lint.yml
+++ b/.github/workflows/pull-request-lint.yml
@@ -9,6 +9,10 @@ on:
       - reopened
       - ready_for_review
       - edited
+  push:
+    branches:
+      - gh-readonly-queue/**
+  merge_group: {}
 
 jobs:
   lint:
@@ -17,7 +21,11 @@ jobs:
     permissions:
       pull-requests: read
     steps:
+      - name: Skip on queue refs
+        if: github.event_name == 'merge_group' || github.event_name == 'push'
+        run: echo "Skipping lint in queue context"
       - name: Lint PR title
+        if: github.event_name == 'pull_request_target'
         uses: p6m7g8-actions/p6-gh-pr-title-linter@main
         with:
           gh_token: ${{ secrets.GITHUB_TOKEN }}

--- a/init.zsh
+++ b/init.zsh
@@ -149,7 +149,7 @@ p6df::modules::perl::prompt::env() {
 #  local str="perl5lib:\t  $PERL5LIB"
   local str=""
   case "$PERL5LIB" in
-    $P6_DFZ_SRC_P6M7G8_DOTFILES_DIR/p6perl/lib/perl5) str="" ;;
+    "$P6_DFZ_SRC_P6M7G8_DOTFILES_DIR/p6perl/lib/perl5") str="" ;;
     *) str="perl5lib:\t  $PERL5LIB" ;;
   esac
 

--- a/init.zsh
+++ b/init.zsh
@@ -146,7 +146,12 @@ p6df::modules::perl::init() {
 p6df::modules::perl::prompt::env() {
 
 #  local str="plenv_root:\t  $PLENV_ROOT
-  local str="perl5lib:\t  $PERL5LIB"
+#  local str="perl5lib:\t  $PERL5LIB"
+  local str=""
+  case "$PERL5LIB" in
+    $P6_DFZ_SRC_P6M7G8_DOTFILES_DIR/p6perl/lib/perl5) str="" ;;
+    *) str="perl5lib:\t  $PERL5LIB" ;;
+  esac
 
   p6_return_str "$str"
 }


### PR DESCRIPTION
## Summary
- `p6df::modules::perl::prompt::env()` now uses a `case` statement to suppress display when `PERL5LIB` matches the default p6perl lib path
- Reduces prompt noise when Perl environment is at default configuration

## Test plan
- [ ] Verify prompt is empty when `PERL5LIB` equals `$P6_DFZ_SRC_P6M7G8_DOTFILES_DIR/p6perl/lib/perl5`
- [ ] Verify prompt shows `perl5lib:` line when `PERL5LIB` is set to a custom path

🤖 Generated with [Claude Code](https://claude.com/claude-code)