### PR TITLE
chore(perl): rename home::symlink to home::symlinks, tighten .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
-share/
+share/.cpanm/build.log
+share/.cpanm/latest-build

--- a/init.zsh
+++ b/init.zsh
@@ -63,6 +63,7 @@ p6df::modules::perl::home::symlinks() {
   p6_dir_mk "$P6_DFZ_SRC_DIR/tokuhirom/plenv/plugins"
   p6_file_symlink "$P6_DFZ_SRC_DIR/tokuhirom/Perl-Build" "$P6_DFZ_SRC_DIR/tokuhirom/plenv/plugins/perl-build"
 
+  p6_dir_mk "$P6_DFZ_SRC_P6M7G8_DOTFILES_DIR/p6df-perl/share/.cpanm"
   p6_file_symlink "$P6_DFZ_SRC_P6M7G8_DOTFILES_DIR/p6df-perl/share/.cpanm" "$HOME/.cpanm"
 
   p6_return_void

--- a/init.zsh
+++ b/init.zsh
@@ -53,12 +53,12 @@ EOF
 ######################################################################
 #<
 #
-# Function: p6df::modules::perl::home::symlink()
+# Function: p6df::modules::perl::home::symlinks()
 #
 #  Environment:	 P6_DFZ_SRC_DIR P6_DFZ_SRC_P6M7G8_DOTFILES_DIR
 #>
 ######################################################################
-p6df::modules::perl::home::symlink() {
+p6df::modules::perl::home::symlinks() {
 
   p6_dir_mk "$P6_DFZ_SRC_DIR/tokuhirom/plenv/plugins"
   p6_file_symlink "$P6_DFZ_SRC_DIR/tokuhirom/Perl-Build" "$P6_DFZ_SRC_DIR/tokuhirom/plenv/plugins/perl-build"

--- a/share/.cpanm/build.log
+++ b/share/.cpanm/build.log
@@ -1,1 +1,0 @@
-/Users/pgollucci/.cpanm/work/1647793549.22863/build.log

--- a/share/.cpanm/latest-build
+++ b/share/.cpanm/latest-build
@@ -1,1 +1,0 @@
-/Users/pgollucci/.cpanm/work/1647793549.22863


### PR DESCRIPTION
## What
Rename singular to plural. Replace overbroad `share/` gitignore with specific cpanm paths.

## Why
Framework dispatches plural only. share/ was hiding cpanm config from tracking; only build logs and state files should be excluded.

## Test plan
- `p6df home symlinks` works correctly
- `git status` shows cpanm config tracked, build.log ignored

## Dependencies
None