### PR TITLE
fix(profile): correct env var reference in profile mod

### DIFF
--- a/init.zsh
+++ b/init.zsh
@@ -159,5 +159,5 @@ p6df::modules::perl::prompt::lang() {
 ######################################################################
 p6df::modules::perl::prompt::env() {
 
-  p6_return_words 'perl' "$"
+  p6_return_words 'perl' '$PERL5LIB'
 }


### PR DESCRIPTION
## What
Fix the `p6df::modules::perl::prompt::env()` function to use `'$PERL5LIB'` instead of a bare `"$"` as the env var argument to `p6_return_words`.

## Why
The previous value `"$"` was a broken/placeholder string that would not correctly reference the Perl library path environment variable. This fix ensures the profile mod returns the correct env var name.

## Test plan
- Verified diff looks correct
- Function now references `\$PERL5LIB` as intended

## Dependencies
None