### PR TITLE
refactor(perl): update function signatures and rename prompt::env return type

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,16 +36,13 @@ TODO: Add a short summary of this module.
 ##### p6df-perl/init.zsh
 
 - `p6df::modules::perl::deps()`
-- `p6df::modules::perl::home::symlink()`
-- `p6df::modules::perl::init(_module, dir)`
-  - Args:
-    - _module -
-    - dir -
+- `p6df::modules::perl::home::symlinks()`
+- `p6df::modules::perl::langmgr::init()`
 - `p6df::modules::perl::langs()`
 - `p6df::modules::perl::vscodes()`
 - `p6df::modules::perl::vscodes::config()`
-- `str str = p6df::modules::perl::prompt::env()`
 - `str str = p6df::modules::perl::prompt::lang()`
+- `words perl = p6df::modules::perl::prompt::env()`
 
 #### p6df-perl/lib
 

--- a/init.zsh
+++ b/init.zsh
@@ -149,10 +149,10 @@ p6df::modules::perl::prompt::lang() {
 ######################################################################
 #<
 #
-# Function: words perl $PERL5LIB = p6df::modules::perl::prompt::env()
+# Function: words perl = p6df::modules::perl::prompt::env()
 #
 #  Returns:
-#	words - perl $PERL5LIB
+#	words - perl
 #
 #  Environment:	 PERL5LIB
 #>


### PR DESCRIPTION
**What:** Update function signatures with proper arg names and fix prompt::env return type declaration

**Why:** Normalizes function documentation to use consistent `words perl` return type and renames `home::symlink` to `home::symlinks`

**Test plan:** Shell loads without errors; perl prompt functions return expected values

**Dependencies:** none